### PR TITLE
Fix mapbook layout

### DIFF
--- a/workflows/mapbook_report/layout.json
+++ b/workflows/mapbook_report/layout.json
@@ -4,9 +4,9 @@
   { "i": "2", "x": 6, "y": 0,  "widget_id": 2, "w": 3,  "h": 3,  "minW": 1, "minH": 3, "static": false },
 
   { "i": "3", "x": 0, "y": 3,  "widget_id": 3, "w": 5, "h": 10, "minW": 4, "minH": 8, "static": false },
-  { "i": "4", "x": 5, "y": 13, "widget_id": 4, "w": 5, "h": 10, "minW": 4, "minH": 8, "static": false },
-  { "i": "5", "x": 0, "y": 23, "widget_id": 5, "w": 5, "h": 10, "minW": 4, "minH": 8, "static": false },
-  { "i": "6", "x": 5, "y": 33, "widget_id": 6, "w": 5, "h": 10, "minW": 4, "minH": 8, "static": false },
-  { "i": "7", "x": 0, "y": 43, "widget_id": 7, "w": 5, "h": 10, "minW": 4, "minH": 8, "static": false },
-  { "i": "8", "x": 5, "y": 53, "widget_id": 8, "w": 5, "h": 10, "minW": 4, "minH": 8, "static": false }
+  { "i": "4", "x": 5, "y": 3, "widget_id": 4, "w": 5, "h": 10, "minW": 4, "minH": 8, "static": false },
+  { "i": "5", "x": 0, "y": 13, "widget_id": 5, "w": 5, "h": 10, "minW": 4, "minH": 8, "static": false },
+  { "i": "6", "x": 5, "y": 13, "widget_id": 6, "w": 5, "h": 10, "minW": 4, "minH": 8, "static": false },
+  { "i": "7", "x": 0, "y": 23, "widget_id": 7, "w": 5, "h": 10, "minW": 4, "minH": 8, "static": false },
+  { "i": "8", "x": 5, "y": 23, "widget_id": 8, "w": 5, "h": 10, "minW": 4, "minH": 8, "static": false }
 ]


### PR DESCRIPTION
## :earth_americas: Summary
Fixes the Mapbook Report workflow's dashboard layout

## :package: Proposed Changes
Corrects the y alignment of dashboard widgets so that these maps appear in pairs on the same row
- Movement Tracks and Home Range 
- Speed map and Mean Speed raster
- Day Night and Seasonal

## 📋 Checklist
- [ ] Unit tests updated (if applicable)
- [ ] test-cases.yaml updated (if applicable)
- [ ] rjsf file changes validated
- [ ] Choose ONE label to run workflow tests:
    - `test:local` - Run workflow tests with local build 
    - `test:published` - Run workflow tests with published packages only on MacOS, Linux and Windows

## :rocket: Checklist for Publishing Workflows
(Only complete if this PR is preparing workflows for customer handover)
- [ ] Task library published to prefix
- [ ] User guide updated

